### PR TITLE
React to Configuration API changes

### DIFF
--- a/samples/Config.CustomSource.Web/Startup.cs
+++ b/samples/Config.CustomSource.Web/Startup.cs
@@ -8,10 +8,7 @@ public class Startup
 {
     public void Configure(IApplicationBuilder app)
     {
-        var config = new Configuration
-        {
-            new MyConfigSource()
-        };
+        var config = new Configuration(new MyConfigSource());
 
         app.Run(async ctx =>
         {

--- a/samples/Config.SettingObject.Web/Startup.cs
+++ b/samples/Config.SettingObject.Web/Startup.cs
@@ -7,8 +7,7 @@ public class Startup
 {
     public void Configure(IApplicationBuilder app)
     {
-        var config = new Configuration
-        {
+        var config = new Configuration(
             new MemoryConfigurationSource
             {
                 {"MySettings:RetryCount", "42"},
@@ -17,8 +16,7 @@ public class Startup
                 {"MySettings:AdBlock:House:Origin", "blob-456"},
                 {"MySettings:AdBlock:Contoso:ProductCode", "contoso2014"},
                 {"MySettings:AdBlock:Contoso:Origin", "sql-789"},
-            }
-        };
+            });
 
         var mySettings = new MySettings();
         mySettings.Read(config.GetSubKey("MySettings"));


### PR DESCRIPTION
`Configuration` is no longer a collection type. Instead, it accepts sources as parameter.