### PR TITLE
Fix security package name

### DIFF
--- a/samples/Owin.IAppBuilderBridge/KAppBuilderExtensions.cs
+++ b/samples/Owin.IAppBuilderBridge/KAppBuilderExtensions.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
-using Microsoft.AspNet.Security.DataProtection;
+using Microsoft.AspNet.DataProtection;
 using Microsoft.Framework.DependencyInjection;
 using Microsoft.Owin.Builder;
 using Owin;

--- a/samples/Owin.IAppBuilderBridge/Owin.IAppBuilderBridge.xproj
+++ b/samples/Owin.IAppBuilderBridge/Owin.IAppBuilderBridge.xproj
@@ -1,0 +1,19 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">14.0</VisualStudioVersion>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+  </PropertyGroup>
+  <Import Project="$(VSToolsPath)\DNX\Microsoft.DNX.Props" Condition="'$(VSToolsPath)' != ''" />
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>600a7aa4-ef5e-4181-b6e9-8354ecee581b</ProjectGuid>
+    <RootNamespace>Owin.IAppBuilderBridge</RootNamespace>
+    <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">..\..\artifacts\obj\$(MSBuildProjectName)</BaseIntermediateOutputPath>
+    <OutputPath Condition="'$(OutputPath)'=='' ">..\..\artifacts\bin\$(MSBuildProjectName)\</OutputPath>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <SchemaVersion>2.0</SchemaVersion>
+  </PropertyGroup>
+  <Import Project="$(VSToolsPath)\DNX\Microsoft.DNX.targets" Condition="'$(VSToolsPath)' != ''" />
+</Project>

--- a/samples/Owin.IAppBuilderBridge/project.json
+++ b/samples/Owin.IAppBuilderBridge/project.json
@@ -14,10 +14,10 @@
     },
     "dependencies": {
         "Microsoft.AspNet.Owin": "1.0.0-*",
-        "Microsoft.AspNet.Security.DataProtection": "1.0.0-*",
+        "Microsoft.AspNet.DataProtection": "1.0.0-*",
         "Microsoft.AspNet.Server.IIS": "1.0.0-*",
         "Microsoft.Framework.DependencyInjection": "1.0.0-*",
-        "Microsoft.Owin": "3.0.0"
+        "Microsoft.Owin": "3.0.0"     
     },
     "frameworks" : {
         "dnx451" : { }


### PR DESCRIPTION
1. One of the packages was renamed but the `project.json` file still had the old name.
2. The xproj for that particular project was missing

cc @Tratcher 