### PR TITLE
Handle non-websocket requests without crashing in sample

### DIFF
--- a/samples/Owin.OwinWebSockets/Startup.cs
+++ b/samples/Owin.OwinWebSockets/Startup.cs
@@ -42,15 +42,17 @@ namespace SelfHostServer
                 {
                     return async env =>
                     {
-                        var accept = env["websocket.Accept"] as WebSocketAccept;
-                        if (accept == null)
+                        object accept;
+                        env.TryGetValue("websocket.Accept", out accept);
+                        var webSocketAccept = accept as WebSocketAccept;
+                        if (webSocketAccept == null)
                         {
                             // Not a websocket request
                             await next(env);
                         }
                         else
                         {
-                            accept(null, WebSocketEcho);
+                            webSocketAccept(null, WebSocketEcho);
                         }
                     };
                 });


### PR DESCRIPTION
Fixes https://github.com/aspnet/Entropy/issues/81. Tested locally to verify that the sample no longer crashes for non-websocket requests.