### PR TITLE
React to HttpAbstractions namespace changes

### DIFF
--- a/samples/Mvc.RenderViewToString/RazorViewToStringRenderer.cs
+++ b/samples/Mvc.RenderViewToString/RazorViewToStringRenderer.cs
@@ -3,7 +3,7 @@
 
 using System;
 using System.IO;
-using Microsoft.AspNetCore.Http.Internal;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Abstractions;
 using Microsoft.AspNetCore.Mvc.ModelBinding;


### PR DESCRIPTION
- aspnet/HttpAbstractions#549 and aspnet/HttpAbstractions#592
- clean up `using`s