### PR TITLE
Use UseServer() instead of UseKestrel() to allow override in tests

### DIFF
--- a/samples/Builder.Filtering.Web/Startup.cs
+++ b/samples/Builder.Filtering.Web/Startup.cs
@@ -47,8 +47,10 @@ namespace Builder.Filtering.Web
         public static void Main(string[] args)
         {
             var host = new WebHostBuilder()
+                // We set the server by name before default args so that command line arguments can override it.
+                // This is used to allow deployers to choose the server for testing.
+                .UseServer("Microsoft.AspNetCore.Server.Kestrel")
                 .UseDefaultHostingConfiguration(args)
-                .UseKestrel()
                 .UseIISIntegration()
                 .UseStartup<Startup>()
                 .Build();

--- a/samples/Builder.Filtering.Web/project.json
+++ b/samples/Builder.Filtering.Web/project.json
@@ -3,6 +3,7 @@
     "Microsoft.AspNetCore.Http": "1.0.0-*",
     "Microsoft.AspNetCore.Server.IISIntegration": "1.0.0-*",
     "Microsoft.AspNetCore.Server.Kestrel": "1.0.0-*",
+    "Microsoft.AspNetCore.Server.WebListener": "0.1.0-*",
     "Microsoft.NETCore.Platforms": "1.0.1-*"
   },
   "frameworks": {

--- a/samples/Builder.HelloWorld.Web/Startup.cs
+++ b/samples/Builder.HelloWorld.Web/Startup.cs
@@ -18,8 +18,10 @@ namespace Builder.HelloWorld.Web
         public static void Main(string[] args)
         {
             var host = new WebHostBuilder()
+                // We set the server by name before default args so that command line arguments can override it.
+                // This is used to allow deployers to choose the server for testing.
+                .UseServer("Microsoft.AspNetCore.Server.Kestrel")
                 .UseDefaultHostingConfiguration(args)
-                .UseKestrel()
                 .UseIISIntegration()
                 .UseStartup<Startup>()
                 .Build();

--- a/samples/Builder.HelloWorld.Web/project.json
+++ b/samples/Builder.HelloWorld.Web/project.json
@@ -1,8 +1,9 @@
 {
   "dependencies": {
     "Microsoft.AspNetCore.Http": "1.0.0-*",
-    "Microsoft.AspNetCore.Server.Kestrel": "1.0.0-*",
     "Microsoft.AspNetCore.Server.IISIntegration": "1.0.0-*",
+    "Microsoft.AspNetCore.Server.Kestrel": "1.0.0-*",
+    "Microsoft.AspNetCore.Server.WebListener": "0.1.0-*",
     "Microsoft.NETCore.Platforms": "1.0.1-*"
   },
   "frameworks": {

--- a/samples/Builder.Middleware.Web/Startup.cs
+++ b/samples/Builder.Middleware.Web/Startup.cs
@@ -17,8 +17,10 @@ namespace Builder.Middleware.Web
         public static void Main(string[] args)
         {
             var host = new WebHostBuilder()
+                // We set the server by name before default args so that command line arguments can override it.
+                // This is used to allow deployers to choose the server for testing.
+                .UseServer("Microsoft.AspNetCore.Server.Kestrel")
                 .UseDefaultHostingConfiguration(args)
-                .UseKestrel()
                 .UseIISIntegration()
                 .UseStartup<Startup>()
                 .Build();

--- a/samples/Builder.Middleware.Web/project.json
+++ b/samples/Builder.Middleware.Web/project.json
@@ -2,6 +2,7 @@
   "dependencies": {
     "Microsoft.AspNetCore.Server.IISIntegration": "1.0.0-*",
     "Microsoft.AspNetCore.Server.Kestrel": "1.0.0-*",
+    "Microsoft.AspNetCore.Server.WebListener": "0.1.0-*",
     "Microsoft.Extensions.DependencyInjection": "1.0.0-*",
     "Microsoft.NETCore.Platforms": "1.0.1-*"
   },

--- a/samples/Config.SettingObject.Web/Startup.cs
+++ b/samples/Config.SettingObject.Web/Startup.cs
@@ -45,8 +45,10 @@ public class Startup
     public static void Main(string[] args)
     {
         var host = new WebHostBuilder()
+            // We set the server by name before default args so that command line arguments can override it.
+            // This is used to allow deployers to choose the server for testing.
+            .UseServer("Microsoft.AspNetCore.Server.Kestrel")
             .UseDefaultHostingConfiguration(args)
-            .UseKestrel()
             .UseIISIntegration()
             .UseStartup<Startup>()
             .Build();

--- a/samples/Config.SettingObject.Web/project.json
+++ b/samples/Config.SettingObject.Web/project.json
@@ -3,8 +3,8 @@
     "Microsoft.AspNetCore.Http": "1.0.0-*",
     "Microsoft.AspNetCore.Server.IISIntegration": "1.0.0-*",
     "Microsoft.AspNetCore.Server.Kestrel": "1.0.0-*",
-    "Microsoft.Extensions.Configuration": "1.0.0-*",
     "Microsoft.AspNetCore.Server.WebListener": "0.1.0-*",
+    "Microsoft.Extensions.Configuration": "1.0.0-*",
     "Microsoft.NETCore.Platforms": "1.0.1-*"
   },
   "frameworks": {

--- a/samples/Container.Fallback.Web/Startup.cs
+++ b/samples/Container.Fallback.Web/Startup.cs
@@ -29,8 +29,10 @@ namespace Container.Fallback.Web
         public static void Main(string[] args)
         {
             var host = new WebHostBuilder()
+                // We set the server by name before default args so that command line arguments can override it.
+                // This is used to allow deployers to choose the server for testing.
+                .UseServer("Microsoft.AspNetCore.Server.Kestrel")
                 .UseDefaultHostingConfiguration(args)
-                .UseKestrel()
                 .UseIISIntegration()
                 .UseStartup<Startup>()
                 .Build();

--- a/samples/Diagnostics.StatusCodes.Mvc/Startup.cs
+++ b/samples/Diagnostics.StatusCodes.Mvc/Startup.cs
@@ -29,8 +29,10 @@ namespace Diagnostics.StatusCodes.Mvc
         public static void Main(string[] args)
         {
             var host = new WebHostBuilder()
+                // We set the server by name before default args so that command line arguments can override it.
+                // This is used to allow deployers to choose the server for testing.
+                .UseServer("Microsoft.AspNetCore.Server.Kestrel")
                 .UseDefaultHostingConfiguration(args)
-                .UseKestrel()
                 .UseIISIntegration()
                 .UseStartup<Startup>()
                 .Build();


### PR DESCRIPTION
Only fixing the samples that are tested for now. We'll need to also update other samples when we add tests in https://github.com/aspnet/Entropy/issues/117. Note the localization failures are due to https://github.com/dotnet/cli/issues/467 which has been fixed by @anurse.

Review: @Tratcher @mikeharder 
Approval: @Eilon @DamianEdwards 