### PR TITLE
Temporary fix for build break

### DIFF
--- a/samples/Localization.StarterWeb/Startup.cs
+++ b/samples/Localization.StarterWeb/Startup.cs
@@ -148,7 +148,6 @@ namespace Localization.StarterWeb
             var config = new ConfigurationBuilder().AddCommandLine(args).Build();
 
             var host = new WebHostBuilder()
-                .UseContentRoot(Directory.GetCurrentDirectory())
                 .UseKestrel()
                 .UseConfiguration(config)
                 .UseIISIntegration()

--- a/samples/Localization.StarterWeb/project.json
+++ b/samples/Localization.StarterWeb/project.json
@@ -3,7 +3,14 @@
   "version": "1.1.0-*",
   "buildOptions": {
     "emitEntryPoint": true,
-    "preserveCompilationContext": true
+    "preserveCompilationContext": true,
+    "copyToOutput": {
+      "include": [
+        "appsettings.json",
+        "Views",
+        "web.config"
+      ]
+    }
   },
   "dependencies": {
     "Microsoft.AspNetCore.Authentication.Cookies": "1.1.0-*",


### PR DESCRIPTION
@pranavkm as discussed offline this is a temporary fix until we fix the deployers in our testing to supply the working directory when running the app

@shanselman Your fix in the latest PR was correct but we have a bug in our end-to-end testing code where we do not handle the current working directory because of which tests are failing. I believe your original intention was to be able to do `dotnet run` on the app and be able to view the application. The fix in this PR makes that scenario work.  This is just a temp fix until we fix the deployer.