### PR TITLE
Fix Class Library example

### DIFF
--- a/samples/Localization.CustomResourceManager/ClassLibraryResourceManagerStringLocalizerFactory.cs
+++ b/samples/Localization.CustomResourceManager/ClassLibraryResourceManagerStringLocalizerFactory.cs
@@ -33,6 +33,12 @@ namespace Localization.CustomResourceManager
             return GetResourcePrefix(typeInfo, assemblyName, GetResourcePath(assemblyName));
         }
 
+        protected override string GetResourcePrefix(TypeInfo typeInfo, string baseNamespace, string resourcesRelativePath)
+        {
+            var assemblyName = new AssemblyName(typeInfo.Assembly.FullName);
+            return base.GetResourcePrefix(typeInfo, baseNamespace, GetResourcePath(assemblyName.Name));
+        }
+
         private string GetResourcePath(string assemblyName)
         {
             string resourcePath;


### PR DESCRIPTION
This is a fix for the broken tests around localization, which were caused by a change it which GetResourcePrefix overloads we used.

@BrennanConroy you seem to be running point on this so let me know if someone else should review.