### PR TITLE
Add simple example of View Localization

### DIFF
--- a/samples/Localization.StarterWeb/Resources/Views/Home/Index.fr.fr.resx
+++ b/samples/Localization.StarterWeb/Resources/Views/Home/Index.fr.fr.resx
@@ -1,0 +1,222 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="&lt;a href=&quot;http://go.microsoft.com/fwlink/?LinkId=518007&quot;&gt;Gulp&lt;/a&gt; and &lt;a href=&quot;http://go.microsoft.com/fwlink/?LinkId=518004&quot;&gt;Bower&lt;/a&gt; for managing client-side libraries" xml:space="preserve">
+    <value>&lt;a href="http://go.microsoft.com/fwlink/?LinkId=518007"&gt;Gulp&lt;/a&gt; et &lt;a href="http://go.microsoft.com/fwlink/?LinkId=518004"&gt;Bower&lt;/a&gt; pour la gestion des bibliothèques côté client</value>
+  </data>
+  <data name="Add a Controller and View" xml:space="preserve">
+    <value>Ajouter un contrôleur et Vue</value>
+  </data>
+  <data name="Application uses" xml:space="preserve">
+    <value>Utilisations d'application</value>
+  </data>
+  <data name="Bring in libraries from NuGet, Bower, and npm, and automate tasks using Grunt or Gulp." xml:space="preserve">
+    <value>Apportez dans les bibliothèques de NuGet , Bower , et NPM , et automatiser les tâches à l'aide Grunt ou Gulp .</value>
+  </data>
+  <data name="Home Page" xml:space="preserve">
+    <value>Page D'accueil</value>
+  </data>
+  <data name="How to" xml:space="preserve">
+    <value>Comment</value>
+  </data>
+  <data name="Learn how Microsoft's Azure cloud platform allows you to build, deploy, and scale web apps." xml:space="preserve">
+    <value>Découvrez comment la plate-forme Azure cloud de Microsoft vous permet de construire, déployer et applications Web à grande échelle .</value>
+  </data>
+  <data name="Learn how to build ASP.NET apps that can run anywhere." xml:space="preserve">
+    <value>Apprenez à créer des applications ASP.NET qui peuvent fonctionner n'importe où .</value>
+  </data>
+  <data name="Learn More" xml:space="preserve">
+    <value>Apprendre Encore Plus</value>
+  </data>
+  <data name="Next" xml:space="preserve">
+    <value>Prochain</value>
+  </data>
+  <data name="Package Management" xml:space="preserve">
+    <value>Gestion des Paquetages</value>
+  </data>
+  <data name="Previous" xml:space="preserve">
+    <value>Précédent</value>
+  </data>
+  <data name="Sample pages using ASP.NET MVC 6" xml:space="preserve">
+    <value>Pages échantillon en utilisant ASP.NET MVC 6</value>
+  </data>
+  <data name="Theming using &lt;a href=&quot;http://go.microsoft.com/fwlink/?LinkID=398939&quot;&gt;Bootstrap&lt;/a&gt;" xml:space="preserve">
+    <value>Thématisation aide &lt;a href="http://go.microsoft.com/fwlink/?LinkID=398939"&gt;Bootstrap&lt;/a&gt;</value>
+  </data>
+  <data name="There are powerful new features in Visual Studio for building modern web apps." xml:space="preserve">
+    <value>Il ya de puissantes nouvelles fonctionnalités de Visual Studio pour la création d'applications web modernes .</value>
+  </data>
+  <data name="Add an appsetting in config and access it in app." xml:space="preserve">
+    <value>Ajoutez un appsetting dans la configuration et y accéder à l'application .</value>
+  </data>
+  <data name="Add client packages using Bower." xml:space="preserve">
+    <value>Ajouter des packages de clients à l'aide Bower.</value>
+  </data>
+  <data name="Add packages using NuGet." xml:space="preserve">
+    <value>Ajouter paquets en utilisant NuGet.</value>
+  </data>
+  <data name="Client side development" xml:space="preserve">
+    <value>Le développement côté client</value>
+  </data>
+  <data name="Conceptual overview of what is ASP.NET 5" xml:space="preserve">
+    <value>Aperçu conceptuel de ce qui est ASP.NET 5</value>
+  </data>
+  <data name="Develop on different platforms" xml:space="preserve">
+    <value>Développer sur différentes plateformes</value>
+  </data>
+  <data name="Fundamentals of ASP.NET 5 such as Startup and middleware." xml:space="preserve">
+    <value>Notions de base ASP.NET 5 tels que le démarrage et middleware.</value>
+  </data>
+  <data name="Manage User Secrets using Secret Manager." xml:space="preserve">
+    <value>Gérer Secrets de l'utilisateur à l'aide de Secret Manager.</value>
+  </data>
+  <data name="Overview" xml:space="preserve">
+    <value>Vue D'ensemble</value>
+  </data>
+  <data name="Publish to Microsoft Azure Web Apps" xml:space="preserve">
+    <value>Publier sur Microsoft Azure Web Apps</value>
+  </data>
+  <data name="Read more on the documentation site" xml:space="preserve">
+    <value>Lire la suite sur le site de documentation</value>
+  </data>
+  <data name="Run &amp; Deploy" xml:space="preserve">
+    <value>Déployer &amp; Exécuter</value>
+  </data>
+  <data name="Run commands in your project.json" xml:space="preserve">
+    <value>Exécuter des commandes dans votre project.json</value>
+  </data>
+  <data name="Run your app" xml:space="preserve">
+    <value>Exécutez votre application</value>
+  </data>
+  <data name="Run your app on .NET Core" xml:space="preserve">
+    <value>Exécutez votre application sur .NET de base</value>
+  </data>
+  <data name="Security" xml:space="preserve">
+    <value>Sécurité</value>
+  </data>
+  <data name="Target development, staging or production environment." xml:space="preserve">
+    <value>Cibler le développement, la mise en scène ou de l'environnement de production.</value>
+  </data>
+  <data name="Use logging to log a message." xml:space="preserve">
+    <value>Utilisez la journalisation pour enregistrer un message.</value>
+  </data>
+  <data name="Working with Data" xml:space="preserve">
+    <value>Utilisation des données</value>
+  </data>
+</root>

--- a/samples/Localization.StarterWeb/Views/Home/Index.fr.cshtml
+++ b/samples/Localization.StarterWeb/Views/Home/Index.fr.cshtml
@@ -1,0 +1,125 @@
+@using Microsoft.AspNetCore.Mvc.Localization
+
+@* The IViewLocalizer can be injected into the view. It does two things of interest:
+    1. It can HTML encode *parameters* passed to resource strings (not the resource strings themselves, as they may contain
+       HTML) automatically, and return the result as an IHtmlContent so Razor won't HTML encode it again;
+    2. It looks for localization resources for this view based on the view path, e.g. if the view's path is
+       "MyApplication/Views/Home/Index.cshtml", then the corresponding resource base path will be "MyApplication.Views.Home.Index" *@
+
+@inject IViewLocalizer Localizer
+
+@{
+    ViewData["Title"] = Localizer["Home Page"];
+}
+
+<div id="myCarousel" class="carousel slide" data-ride="carousel" data-interval="6000">
+    <ol class="carousel-indicators">
+        <li data-target="#myCarousel" data-slide-to="0" class="active"></li>
+        <li data-target="#myCarousel" data-slide-to="1"></li>
+        <li data-target="#myCarousel" data-slide-to="2"></li>
+        <li data-target="#myCarousel" data-slide-to="3"></li>
+    </ol>
+    <div class="carousel-inner" role="listbox">
+        <div class="item active">
+            <img src="~/images/ASP-NET-Banners-01.png" alt="ASP.NET" class="img-responsive" />
+            <div class="carousel-caption">
+                <p>
+                    @Localizer["Learn how to build ASP.NET apps that can run anywhere."]
+                    <a class="btn btn-default btn-default" href="http://go.microsoft.com/fwlink/?LinkID=525028&clcid=0x409">
+                        @Localizer["Learn More"]
+                    </a>
+                </p>
+            </div>
+        </div>
+        <div class="item">
+            <img src="~/images/Banner-02-VS.png" alt="Visual Studio" class="img-responsive" />
+            <div class="carousel-caption">
+                <p>
+                    @Localizer["There are powerful new features in Visual Studio for building modern web apps."]
+                    <a class="btn btn-default btn-default" href="http://go.microsoft.com/fwlink/?LinkID=525030&clcid=0x409" asp-loc>
+                        Learn More
+                    </a>
+                </p>
+            </div>
+        </div>
+        <div class="item">
+            <img src="~/images/ASP-NET-Banners-02.png" alt="Package Management" asp-loc-alt class="img-responsive" />
+            <div class="carousel-caption">
+                <p>
+                    @Localizer["Bring in libraries from NuGet, Bower, and npm, and automate tasks using Grunt or Gulp."]
+                    <a class="btn btn-default btn-default" href="http://go.microsoft.com/fwlink/?LinkID=525029&clcid=0x409">
+                        @Localizer["Learn More"]
+                    </a>
+                </p>
+            </div>
+        </div>
+        <div class="item">
+            <img src="~/images/Banner-01-Azure.png" alt="Microsoft Azure" class="img-responsive" />
+            <div class="carousel-caption">
+                <p>
+                    @Localizer["Learn how Microsoft's Azure cloud platform allows you to build, deploy, and scale web apps."]
+                    <a class="btn btn-default btn-default" href="http://go.microsoft.com/fwlink/?LinkID=525027&clcid=0x409">
+                        @Localizer["Learn More"]
+                    </a>
+                </p>
+            </div>
+        </div>
+    </div>
+    <a class="left carousel-control" href="#myCarousel" role="button" data-slide="prev">
+        <span class="glyphicon glyphicon-chevron-left" aria-hidden="true"></span>
+        <span class="sr-only" asp-loc>Previous</span>
+    </a>
+    <a class="right carousel-control" href="#myCarousel" role="button" data-slide="next">
+        <span class="glyphicon glyphicon-chevron-right" aria-hidden="true"></span>
+        <span class="sr-only" asp-loc>Next</span>
+    </a>
+</div>
+
+<div class="row">
+    <div class="col-md-3">
+        <strong>This View has been localized to french using View Localization.</strong>
+    </div>
+</div>
+<div class="row">
+    <div class="col-md-3">
+        <h2 asp-loc>Application uses</h2>
+        <ul>
+            <li asp-loc>Sample pages using ASP.NET MVC 6</li>
+            <li asp-loc><a href="http://go.microsoft.com/fwlink/?LinkId=518007">Gulp</a> and <a href="http://go.microsoft.com/fwlink/?LinkId=518004">Bower</a> for managing client-side libraries</li>
+            <li asp-loc>Theming using <a href="http://go.microsoft.com/fwlink/?LinkID=398939">Bootstrap</a></li>
+        </ul>
+    </div>
+    <div class="col-md-3">
+        <h2 asp-loc>How to</h2>
+        <ul>
+            <li><a href="http://go.microsoft.com/fwlink/?LinkID=398600" asp-loc>Add a Controller and View</a></li>
+            <li><a href="http://go.microsoft.com/fwlink/?LinkID=699314" asp-loc>Add an appsetting in config and access it in app.</a></li>
+            <li><a href="http://go.microsoft.com/fwlink/?LinkId=699315" asp-loc>Manage User Secrets using Secret Manager.</a></li>
+            <li><a href="http://go.microsoft.com/fwlink/?LinkId=699316" asp-loc>Use logging to log a message.</a></li>
+            <li><a href="http://go.microsoft.com/fwlink/?LinkId=699317" asp-loc>Add packages using NuGet.</a></li>
+            <li><a href="http://go.microsoft.com/fwlink/?LinkId=699318" asp-loc>Add client packages using Bower.</a></li>
+            <li><a href="http://go.microsoft.com/fwlink/?LinkId=699319" asp-loc>Target development, staging or production environment.</a></li>
+        </ul>
+    </div>
+    <div class="col-md-3">
+        <h2>@Localizer["Overview"]</h2>
+        <ul>
+            <li><a href="http://go.microsoft.com/fwlink/?LinkId=518008">@Localizer["Conceptual overview of what is ASP.NET 5"]</a></li>
+            <li><a href="http://go.microsoft.com/fwlink/?LinkId=699320">@Localizer["Fundamentals of ASP.NET 5 such as Startup and middleware."]</a></li>
+            <li><a href="http://go.microsoft.com/fwlink/?LinkId=398602">@Localizer["Working with Data"]</a></li>
+            <li><a href="http://go.microsoft.com/fwlink/?LinkId=398603">@Localizer["Security"]</a></li>
+            <li><a href="http://go.microsoft.com/fwlink/?LinkID=699321">@Localizer["Client side development"]</a></li>
+            <li><a href="http://go.microsoft.com/fwlink/?LinkID=699322">@Localizer["Develop on different platforms"]</a></li>
+            <li><a href="http://go.microsoft.com/fwlink/?LinkID=699323">@Localizer["Read more on the documentation site"]</a></li>
+        </ul>
+    </div>
+    <div class="col-md-3">
+        <h2>@Localizer["Run & Deploy"]</h2>
+        <ul>
+            <li><a href="http://go.microsoft.com/fwlink/?LinkID=517851">@Localizer["Run your app"]</a></li>
+            <li><a href="http://go.microsoft.com/fwlink/?LinkID=517852">@Localizer["Run your app on .NET Core"]</a></li>
+            <li><a href="http://go.microsoft.com/fwlink/?LinkID=517853">@Localizer["Run commands in your project.json"]</a></li>
+            <li><a href="http://go.microsoft.com/fwlink/?LinkID=398609">@Localizer["Publish to Microsoft Azure Web Apps"]</a></li>
+        </ul>
+    </div>
+</div>


### PR DESCRIPTION
Fixes #127. The relevent change here (as it gets a little burried in reading the cshtml) is that we added a `<strong>` field alerting people that this is a View Localized page.

The extra resource file is nescesary due to aspnet/Mvc#5441, if that were to be resolved we'd be able to delete it as it's identical to `Index.fr.resx`.

