### PR TITLE
Bump test projects up to .NET 4.5.2

### DIFF
--- a/test/FunctionalTests/FunctionalTests.csproj
+++ b/test/FunctionalTests/FunctionalTests.csproj
@@ -3,7 +3,8 @@
   <Import Project="..\..\build\common.props" />
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp1.1;net451</TargetFrameworks>
+    <TargetFrameworks>netcoreapp1.1;net452</TargetFrameworks>
+    <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netcoreapp1.1</TargetFrameworks>
     <DefineConstants>$(DefineConstants);__RemoveThisBitTo__GENERATE_BASELINES</DefineConstants>
     <!-- set explicitly because some tests depend on this -->
     <RootNamespace>FunctionalTests</RootNamespace>
@@ -46,7 +47,7 @@
     <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0-*" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net451' ">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net452' ">
     <ProjectReference Include="..\..\samples\Mvc.LocalizationSample.Web\Mvc.LocalizationSample.Web.csproj" />
   </ItemGroup>
 

--- a/test/FunctionalTests/MvcTests/LocalizationSampleTest.cs
+++ b/test/FunctionalTests/MvcTests/LocalizationSampleTest.cs
@@ -1,7 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-#if NET451
+#if NET452
 using System;
 using System.Collections.Generic;
 using System.Net.Http;

--- a/test/FunctionalTests/TestServices.cs
+++ b/test/FunctionalTests/TestServices.cs
@@ -17,7 +17,7 @@ namespace EntropyTests
     public static class TestServices
     {
         public static string WorkingDirectory { get; }
-#if NET451
+#if NET452
             = AppDomain.CurrentDomain.BaseDirectory;
 #else
             = AppContext.BaseDirectory;


### PR DESCRIPTION
- aspnet/Testing#248
- xUnit no longer supports .NET 4.5.1
- build tests for desktop .NET only on Windows