### PR TITLE
remove integration test logging

### DIFF
--- a/test/Entropy.FunctionalTests/E2ETestBase.cs
+++ b/test/Entropy.FunctionalTests/E2ETestBase.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -7,9 +7,9 @@ using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Server.IntegrationTesting;
-using Microsoft.AspNetCore.Server.IntegrationTesting.xunit;
 using Microsoft.AspNetCore.Testing.xunit;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Testing;
 using Xunit;
 using Xunit.Abstractions;
 


### PR DESCRIPTION
The `LoggedTest` helper has been moved to `Microsoft.Extensions.Logging.Testing` repo.

React to aspnet/Hosting#1039